### PR TITLE
Use MCP server as tool in OpenAI demo

### DIFF
--- a/notebooks/mcp_openai_demo.ipynb
+++ b/notebooks/mcp_openai_demo.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# MCP server demo\n",
         "This notebook connects to the MCP server defined in this repository and\n",
-        "uses the result in a request to the OpenAI Chat Completions API."
+        "registers it as a tool in an OpenAI Chat Completions request so the model can call the server directly."
       ]
     },
     {
@@ -34,19 +34,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {},
-      "outputs": [],
-      "source": [
-        "resource = mcp_request('read_resource', {'id': 'cat_fact'})\n",
-        "fact = resource['result']['data']['fact']\n",
-        "print(fact)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
       "outputs": [],
       "source": [
         "api_key = os.environ.get('OPENAI_API_KEY')\n",
@@ -57,7 +46,14 @@
         "    'model': 'gpt-4o-mini',\n",
         "    'messages': [\n",
         "        {'role': 'system', 'content': 'You are a helpful assistant.'},\n",
-        "        {'role': 'user', 'content': f'Summarize this cat fact: {fact}'}\n",
+        "        {'role': 'user', 'content': 'Fetch a cat fact using the MCP server and summarize it.'}\n",
+        "    ],\n",
+        "    'tools': [\n",
+        "        {\n",
+        "            'type': 'mcp',\n",
+        "            'server_url': SERVER_URL,\n",
+        "            'api_key': API_KEY\n",
+        "        }\n",
         "    ]\n",
         "}).encode()\n",
         "\n",


### PR DESCRIPTION
## Summary
- Register MCP server as a tool in the OpenAI Chat Completions request within the demo notebook
- Allow the model to fetch cat facts by calling the MCP server directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0d9d584c8832ca2c6b5397436be79